### PR TITLE
Clean-up README.md: Grammar, Structure, and Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
-<p align="center">
-    <img src="https://i.goopics.net/77bvma.png" width="256">
-</p>
+<img src="https://i.goopics.net/77bvma.png" width="256" alt="Logo" style="display: block; margin-left: auto; margin-right: auto; width: 25%">
 
-BulMultiverse is an ultra-optimized lightweight world management plugin. Compatible with version 1.8 to the Latest Minecrat version. Unlike the default Multiverse-Core plugin, BulMultiverse is designed to be lean and efficient, without any unnecessary listeners.. This plugin don't contain and will never contain any listeners for any reason.
-[Download page](https://www.spigotmc.org/resources/118884/ "Click to download")
+**BulMultiverse** is an ultra-optimized, lightweight, world management _Spigot_ plugin for _Minecraft: Java Edition_.
+It is compatible with a wide array of versions: from legacy Minecraft 1.8 to modern 1.20+.
+Unlike _MultiVerse Core_, **BulMultiverse** is designed to be lean and efficient &mdash; without any unnecessary listeners.
 
-<img src="https://img.shields.io/badge/Table_of_contents-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
+This plugin does not, or ever will, contain event listeners for any reason.
+[Check it out on SpigotMC](https://www.spigotmc.org/resources/118884/ "Go to SpigotMC").
+
+<img src="https://img.shields.io/badge/Table_of_contents-50C878?style=for-the-badge" alt="Table of Contents" style="pointer-events: none;">
 
 1. [Features](#features)
-1. [Configuration file](#configuration-file)
-2. [Commands and permissions](#commands-and-permissions)
-3. [Flags](#flags)
-4. [How to delete a world](#how-to-delete-a-world)
-5. [Addons](#addons)
-6. [Distribution](#distribution)
+2. [Configuration file](#configuration-file)
+3. [Commands and permissions](#commands-and-permissions)
+4. [Flags](#flags)
+5. [How to delete a world](#how-to-delete-a-world)
+6. [Addons](#addons)
+7. [Distribution](#distribution)
 
-<img id="features" src="https://img.shields.io/badge/Features-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
+<img id="features" src="https://img.shields.io/badge/Features-50C878?style=for-the-badge" alt="Features" style="pointer-events: none;">
 
-- Create world with customizable settings (e.g seed, difficulty, etc).
-- Modify Existing World Settings (e.g, difficulty, PvP, etc).
+- Create world with customizable settings (e.g. seed, difficulty, etc.)
+- Modify Existing World Settings (e.g, difficulty, PvP, etc.)
 - Teleport between world.
 - Load existing world.
 - List loaded worlds.
@@ -46,79 +48,92 @@ messages:
   no_permission: "&e[BULMultiverse] &cYou don't have the permission to do that"
 ```
 
-<img id="commands-and-permissions" src="https://img.shields.io/badge/Commands_and_permissions-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
+<img id="commands-and-permissions" src="https://img.shields.io/badge/Commands_and_permissions-50C878?style=for-the-badge" alt="Commands and Permissions" style="pointer-events: none;">
 
-| Command                         | Description                                                       | Permission          |
-|---------------------------------|-------------------------------------------------------------------|---------------------|
-| bmv create [World Name] (Flags) | Create a world with the given name and optionals flags            | bulmultiverse.admin |
-| bmv load [World Name]           | Load the target existing world                                    | bulmultiverse.admin |
-| bmv unload [World Name]         | UnLoad the target existing world (This doesn't remove the folder) | bulmultiverse.admin |
-| bmv set [World Name] [Flag]     | Set the flag for the target world                                 | bulmultiverse.admin |
-| bmv tp [World Name]             | Teleport to the target world                                      | bulmultiverse.admin |
-| bmv list                        | List all the loaded worlds                                        | bulmultiverse.admin |
-| bmv help                        | Display the in-game help                                          | bulmultiverse.admin |
-| bmv flags                       | Display all the availables flag                                   | bulmultiverse.admin |
+| Command                           | Description                                                          | Permission          |
+|-----------------------------------|----------------------------------------------------------------------|---------------------|
+| bmv create \[World Name\] (Flags) | Create a world with the given name (and optional flags.)             | bulmultiverse.admin |
+| bmv load \[World Name\]           | Load an existing target world.                                       | bulmultiverse.admin |
+| bmv unload \[World Name\]         | Unload an existing world. (This does not remove the world's folder.) | bulmultiverse.admin |
+| bmv set \[World Name\] \[Flag\]   | Set the flags for a given world.                                     | bulmultiverse.admin |
+| bmv tp \[World Name\]             | Teleport to the target world.                                        | bulmultiverse.admin |
+| bmv list                          | List all the loaded worlds.                                          | bulmultiverse.admin |
+| bmv help                          | Display the in-game help.                                            | bulmultiverse.admin |
+| bmv flags                         | Display all the available flags.                                     | bulmultiverse.admin |
 
-<img id="flags" src="https://img.shields.io/badge/Flags-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
+<img id="flags" src="https://img.shields.io/badge/Flags-50C878?style=for-the-badge" alt="Flags." style="pointer-events: none;">
 
-| Command            | Description                                           | example                             |
-|--------------------|-------------------------------------------------------|-------------------------------------|
-| -s [Number]        | Create a world with the given seed                    | /bmv create exemple -s 15648648949  |
-| -b [true or false] | Enable the default builds in the world (e.g, village) | /bmv create exemple -b false        |
-| -e [Environment]   | Set the environment (e.g, nether)                     | /bmv create exemple -e the_end      |
-| -p [true or false] | Enable the pvp                                        | /bmv create exemple -p false        |
-| -t [Type]          | Set type (e.g, flat, amplified)                       | /bmv create exemple -t large_biomes |
-| -d [Difficulty]    | Set difficulty (e.g, easy, hard)                      | /bmv create exemple -d peaceful     |
+| Command            | Description                                            | example                             |
+|--------------------|--------------------------------------------------------|-------------------------------------|
+| -s [Number]        | Specify the world generation seed.                     | /bmv create example -s 15648648949  |
+| -b [true or false] | Enable default structures in the world (i.e., village) | /bmv create example -b false        |
+| -e [Environment]   | Set the environment (e.g, nether)                      | /bmv create example -e the_end      |
+| -p [true or false] | Enable \| Disable Player-vs-Player interactions.       | /bmv create example -p false        |
+| -t [Type]          | Specify the world type (e.g, flat, amplified)          | /bmv create example -t large_biomes |
+| -d [Difficulty]    | Set the world's difficulty (e.g, easy, hard)           | /bmv create example -d peaceful     |
 
-You can chain flags together, for example:
+Flags can be chained together. For example, to create a flat world, on peaceful difficulty, without PvP:
 `/bmv create exemple -d peaceful -p false -t flat`
 
-Missed a flag during creation? You can set it later using the set command:
+Missed a flag during creation? You can set it later using the set command: <br/>
 `/bmv set exemple -d peaceful`
-> NOTE
-> Some flags like the seed, cannot be changed after the world is created. If you make an error in the command, such as setting an invalid difficulty:
-'/bmv create exemple -d SUPERHARDCORP'
-the default difficulty will be used instead. Be sure to check the console for errors when creating worlds.
 
-<img id="how-to-delete-a-world" src="https://img.shields.io/badge/How_to_delete_a_world-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
+> **NOTE**: Some flags cannot be changed after the world is created. 
+> 
+> Be sure to check the console for errors when creating worlds.<br>
+> If you make an error in the command, such as setting an invalid difficulty, the default value will be used instead.
+> Example: `/bmv create example -d SUPERHARDCORP` would create an 'example' world, with the default difficulty.
+ 
 
-BulMultiverse does not delete server files or folders directly. To remove a world:
+
+<img id="how-to-delete-a-world" src="https://img.shields.io/badge/How_to_delete_a_world-50C878?style=for-the-badge" alt="How to delete a world." style="pointer-events: none;">
+
+BulMultiverse does _**not**_ delete server files or folders directly.
+
+To remove a world:
 1. Stop your server.
 2. Manually delete the world's folder.
 3. Restart your server.
 
-BulMultiverse will detect that the world folder is missing and automatically remove it from its worlds.yml file.
+BulMultiverse will detect that the world folder is missing and automatically remove it from it's `worlds.yml` file.
 
-<img id="addons" src="https://img.shields.io/badge/Addons-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
 
-> /!\ DO NOT RENAME THE ADDONS JAR FILE, OR THE PLUGIN WILL NOT DETECT THEM
+
+<img id="addons" src="https://img.shields.io/badge/Addons-50C878?style=for-the-badge" alt="Addons" style="pointer-events: none;">
+
+> ⚠️ **DO NOT RENAME THE ADDON JAR FILES! THE PLUGIN WILL NOT DETECT THEM.** ⚠️
 
 So the default BulMultiverse.jar is very light and optimized, but what if you want an additional specific feature ?
 
-To address this, I've created a robust addons system. This means you can add a specific .jar file (for example, PerWorldInventory.jar)
+To address this, I've created a robust addons system.
+This means you can add a specific .jar file (for example, _PerWorldInventory.jar_)
 to the 'addons' folder within the BulMultiverse directory, and you'll have a new feature: PerWorldInventory!
 
 #### VoidWorld
 
-This addon allow you to create a totally empty world. [Download page](https://www.spigotmc.org/resources/119020/ "Click to download")
+The VoidWorld addon allows you to create a totally empty world.<br>
+[Check it out on SpigotMC](https://www.spigotmc.org/resources/119020/ "Check it out on SpigotMC")
 
 | Type    | value     | Description                     | example                     |
 |---------|-----------|---------------------------------|-----------------------------|
-| flag    | -c void   | Create a empty world (void)     | /bmv create exemple -c void |
+| flag    | -c void   | Create a empty world (void)     | /bmv create example -c void |
 | command | /setblock | Create a block at your position | /setblock                   |
 
 #### PerWorldInventory
 
-WORK IN PROGRESS. To be notified join the discord https://discord.gg/wxnTV68dX2
+**_WORK IN PROGRESS_** <br>
+To be notified [join our Discord server](https://discord.gg/wxnTV68dX2).
 
 #### GuiWorldManager
 
-WORK IN PROGRESS. To be notified join the discord https://discord.gg/wxnTV68dX2
+**_WORK IN PROGRESS_** <br>
+To be notified [join our Discord server](https://discord.gg/wxnTV68dX2).
 
 #### Portal
 
-WORK IN PROGRESS. To be notified join the discord https://discord.gg/wxnTV68dX2
+**_WORK IN PROGRESS_** <br>
+To be notified [join our Discord server](https://discord.gg/wxnTV68dX2).
 
-<img id="distribution" src="https://img.shields.io/badge/Distribution-50C878?style=for-the-badge" alt="Configuration file" style="pointer-events: none;">
+<img id="distribution" src="https://img.shields.io/badge/Distribution-50C878?style=for-the-badge" alt="Distribution" style="pointer-events: none;">
 
-This is a public plugin. You are free to use it and create a fork to develop your own version. However you are not allowed to sell or distribute it in a private manner.
+This is a public plugin. You are free to use it and create a fork to develop your own version. However, you are not allowed to sell or distribute it in a private manner.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<img src="https://i.goopics.net/77bvma.png" width="256" alt="Logo" style="display: block; margin-left: auto; margin-right: auto; width: 25%">
+<p align="center">
+  <img src="https://i.goopics.net/77bvma.png" width="256" alt="Logo" style="display: block; margin-left: auto; margin-right: auto; width: 25%">
+</p>
+
 
 **BulMultiverse** is an ultra-optimized, lightweight, world management _Spigot_ plugin for _Minecraft: Java Edition_.
 It is compatible with a wide array of versions: from legacy Minecraft 1.8 to modern 1.20+.


### PR DESCRIPTION
Images:
- Icon: ~~Remove `<p align="center"></p>` tag wrapping~~
  - Reverted, GitHub's markdown rendering respects this deprecated tag, but not the Image's inline CSS. 
- Icon: Apply CSS styling to re-center and scale with render area width.
  - Not respected by GitHub, but is respected by IntelliJ.
  - Already did the work to add it, so might as well keep it as a backup option.
- Badges: 🦽  Change alt-text to match IDs

General:
- Some restructuring of paragraphs.
- Escaped `[` & `]` in tables, where they are not meant to be Markdown links.
- Fix non-critical markdown errors
- Apply various grammatical changes
- Check spellings (`exemple` -> `example`)
- Fix acronyms and abbreviations. (`e.g` -> `e.g.`)