### PR TITLE
Code Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <relocations>
                         <relocation>

--- a/src/main/java/com/alihaine/bulmultiverse/BulMultiverse.java
+++ b/src/main/java/com/alihaine/bulmultiverse/BulMultiverse.java
@@ -3,6 +3,7 @@ package com.alihaine.bulmultiverse;
 import com.alihaine.bulmultiverse.command.BMV;
 import com.alihaine.bulmultiverse.file.ConfigFile;
 import com.alihaine.bulmultiverse.file.WorldsFile;
+import com.alihaine.bulmultiverse.message.Message;
 import com.alihaine.bulmultiverse.world.WorldDataManager;
 import com.alihaine.bulmultiverse.world.WorldOptionManager;
 import org.bstats.bukkit.Metrics;
@@ -56,8 +57,9 @@ public class BulMultiverse extends JavaPlugin {
     private void loadAddons() {
         File addonsFolder = new File(this.getDataFolder() + "/addons");
         if(!addonsFolder.exists()) {
-            addonsFolder.mkdir();
-            saveResource("addons/how_to_use.txt", false);
+            if (addonsFolder.mkdir()) {
+                saveResource("addons/how_to_use.txt", false);
+            }
             return;
         }
 

--- a/src/main/java/com/alihaine/bulmultiverse/BulMultiverse.java
+++ b/src/main/java/com/alihaine/bulmultiverse/BulMultiverse.java
@@ -34,7 +34,7 @@ public class BulMultiverse extends JavaPlugin {
 
         worldDataManager = new WorldDataManager();
         worldOptionManager = new WorldOptionManager();
-        worldOptionManager.loadDefaultOption();;
+        worldOptionManager.loadDefaultOption();
 
         bmv = new BMV();
         this.getCommand("bmv").setExecutor(bmv);

--- a/src/main/java/com/alihaine/bulmultiverse/BulMultiverse.java
+++ b/src/main/java/com/alihaine/bulmultiverse/BulMultiverse.java
@@ -57,7 +57,7 @@ public class BulMultiverse extends JavaPlugin {
         File addonsFolder = new File(this.getDataFolder() + "/addons");
         if(!addonsFolder.exists()) {
             addonsFolder.mkdir();
-            saveResource("addons/how_to_use.yml", false);
+            saveResource("addons/how_to_use.txt", false);
             return;
         }
 

--- a/src/main/java/com/alihaine/bulmultiverse/BulMultiverseAddon.java
+++ b/src/main/java/com/alihaine/bulmultiverse/BulMultiverseAddon.java
@@ -1,6 +1,7 @@
 package com.alihaine.bulmultiverse;
 
 import java.io.*;
+import java.nio.file.Files;
 
 public abstract class BulMultiverseAddon {
     public abstract void onEnable();
@@ -9,20 +10,20 @@ public abstract class BulMultiverseAddon {
 
     public File createCustomFile(String fileName, InputStream defaultValues) throws IOException {
         File newFile = new File(BulMultiverse.getBulMultiverseInstance().getDataFolder(), fileName);
+
         if (!newFile.exists()) {
-            newFile.getParentFile().mkdirs();
-            try {
-                newFile.createNewFile();
-                copyDefaultResource(fileName, newFile, defaultValues);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            File parentFile = newFile.getParentFile();
+            if (parentFile.mkdirs()) {
+                if (newFile.createNewFile()) {
+                    copyDefaultResource(fileName, newFile, defaultValues);
+                }
             }
         }
         return newFile;
     }
 
     private void copyDefaultResource(String fileName, File file, InputStream defaultValues) throws IOException  {
-        try (OutputStream out = new FileOutputStream(file)) {
+        try (OutputStream out = Files.newOutputStream(file.toPath())) {
 
             if (defaultValues == null) {
                 throw new IllegalArgumentException("Resource not found: " + fileName);

--- a/src/main/java/com/alihaine/bulmultiverse/command/subcommands/Teleport.java
+++ b/src/main/java/com/alihaine/bulmultiverse/command/subcommands/Teleport.java
@@ -19,17 +19,20 @@ public class Teleport implements SubCommand {
             new Message(MessageType.ONLY_INGAME_COMMAND).sendMessage(sender);
             return;
         }
+        if (args.isEmpty()) {
+            new Message(MessageType.NO_WORLD_TARGET).sendMessage(sender);
+            return;
+        }
 
         Player player = (Player) sender;
-        try {
-            World world = Bukkit.getWorld(args.get(0));
+        World world = Bukkit.getWorld(args.get(0));
+        if (world == null) {
+            new Message(MessageType.WORLD_NOT_FOUND).withPlaceHolder(PlaceHolder.NAME, args.get(0)).sendMessage(sender);
+        } else {
             player.teleport(world.getSpawnLocation());
             new Message(MessageType.CMD_TELEPORT_SUCCESS).withPlaceHolder(PlaceHolder.NAME, world.getName()).sendMessage(sender);
-        } catch (NullPointerException exception) {
-            new Message(MessageType.WORLD_NOT_FOUND).withPlaceHolder(PlaceHolder.NAME, args.get(0)).sendMessage(sender);
-        } catch (ArrayIndexOutOfBoundsException exception) {
-            new Message(MessageType.NO_WORLD_TARGET).sendMessage(sender);
         }
+
     }
 
     @Override

--- a/src/main/java/com/alihaine/bulmultiverse/file/WorldsFile.java
+++ b/src/main/java/com/alihaine/bulmultiverse/file/WorldsFile.java
@@ -18,8 +18,10 @@ public class WorldsFile {
     public WorldsFile(BulMultiverse bulMultiverseInstance) {
         file = new File(bulMultiverseInstance.getDataFolder(), "worlds.yml");
         if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            bulMultiverseInstance.saveResource("worlds.yml", false);
+            File parentFile = file.getParentFile();
+            if (parentFile.mkdirs()) {
+                bulMultiverseInstance.saveResource("worlds.yml", false);
+            }
         }
 
         fileConfiguration = new YamlConfiguration();

--- a/src/main/java/com/alihaine/bulmultiverse/message/MessageType.java
+++ b/src/main/java/com/alihaine/bulmultiverse/message/MessageType.java
@@ -13,5 +13,5 @@ public enum MessageType {
     HELP_PATTERN,
     FLAGS_PATTERN,
     ONLY_INGAME_COMMAND,
-    NO_PERMISSION;
+    NO_PERMISSION
 }

--- a/src/main/java/com/alihaine/bulmultiverse/options/Pvp.java
+++ b/src/main/java/com/alihaine/bulmultiverse/options/Pvp.java
@@ -2,7 +2,6 @@ package com.alihaine.bulmultiverse.options;
 
 import com.alihaine.bulmultiverse.world.WorldData;
 import com.alihaine.bulmultiverse.world.WorldOption;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.bukkit.World;
 
 public class Pvp extends WorldOption {

--- a/src/main/resources/addons/how_to_use.txt
+++ b/src/main/resources/addons/how_to_use.txt
@@ -1,4 +1,5 @@
 Want to add specific features to the default BulMultiverse? Check out the available addons.
-Just place an addon in this folder and restart your server. More information: https://github.com/AliHaine/BulMultiverse#addons
+Just place an addon in this folder and restart your server.
+More information: https://github.com/AliHaine/BulMultiverse#addons
 
 /!\ DONT RENAME THE ADDONS JAR FILE OR THE PLUGIN WILL NOT DETECT THEM


### PR DESCRIPTION
This PR tackles the few issues I found while self-auditing the code.

1. Changes from using `spigot` to using the `spigot-api`, and bumps from 1.20.1 to 1.21.1.
  - spigot-api is a smaller dependency (3.1 MiB vs 73 MiB | 95.75% smaller!)
  - Does not require a 3rd party download, or use of the BuildTools.jar
  - Spigot can cause issues when developing with an Eclipse-based IDE. [See the 3rd Question in the BuildTools FAQ](https://www.spigotmc.org/wiki/buildtools/#frequently-asked-questions)
2. Removes some try/catch statements.
  - Try/Catch is more expensive to execute than simple branching.
  - [You're not supposed to catch NullPointerExceptions.](https://wiki.sei.cmu.edu/confluence/display/java/ERR08-J.+Do+not+catch+NullPointerException+or+any+of+its+ancestors)
3. Wrap IO operations that return a value.
4. Change how-to-use to a TXT file (it's not a YAML configuration)