### PR TITLE
Allow World Unloading With Players

### DIFF
--- a/src/main/java/com/alihaine/bulmultiverse/command/subcommands/Unload.java
+++ b/src/main/java/com/alihaine/bulmultiverse/command/subcommands/Unload.java
@@ -4,8 +4,10 @@ import com.alihaine.bulmultiverse.BulMultiverse;
 import com.alihaine.bulmultiverse.command.SubCommand;
 import com.alihaine.bulmultiverse.file.Message;
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.util.List;
 
@@ -23,13 +25,22 @@ public class Unload implements SubCommand {
             return;
         }
 
-        if (!world.getPlayers().isEmpty()) {
-            sender.sendMessage("§cYou can't unload a world who contain players");
+        List<Player> players = world.getPlayers();
+        if (!players.isEmpty()) {
+            World defaultworld = Bukkit.getWorlds().get(0);
+            Location spawn = defaultworld.getSpawnLocation();
+            for (Player player : players) {
+                player.teleport(spawn);
+            }
+        }
+
+        boolean success = Bukkit.unloadWorld(world, true);
+        if (!success) {
+            new Message("cmd_unload_failed").withPlaceHolder("name", world.getName()).sendMessage(sender);
             return;
         }
 
         BulMultiverse.getWorldsFileInstance().removeWorldFromFile(world.getName());
-        Bukkit.unloadWorld(world, true);
         new Message("cmd_unload_success").withPlaceHolder("name", args.get(0)).sendMessage(sender);
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,7 @@ messages:
   cmd_load_success: "&e[BULMultiverse] &aworld: &2%name% &aloaded."
   cmd_teleport_success: "&e[BULMultiverse] &aYou are teleported to the world: &2%name%."
   cmd_unload_success: "&e[BULMultiverse] &aThe world: &2%name% is unload."
+  cmd_unload_failed: "&e[BULMultiverse] &cFailed to unload the world: &e%name%."
   error_set_option: "&e[BULMultiverse] &cImpossible to set this option."
   error_world_creator: "&e[BULMultiverse] &cThis option does not support WorldCreator."
   infos_pattern: "&e%name% &8| &e%value%"


### PR DESCRIPTION
This PR adds the ability for players to unload a world while there are still players on it by teleporting all players to the default world spawn before it gets unloaded.

Also adds a condition to check if the world unloading was successful and sends a message from the config if it fails.

Resolves issue #1.